### PR TITLE
isOfModel filter

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:Summary"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "dependsOn": ["clean"]
+        },
+        {
+            "label": "clean",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "clean",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:Summary"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "none",
+                "isDefault": false
+            },
+        },
+    ]
+}

--- a/QueryBuilder.Test/Models/Hallway.cs
+++ b/QueryBuilder.Test/Models/Hallway.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace QueryBuilder.UnitTests
+{
+    using System.Text.Json.Serialization;
+
+    public class Hallway : Space
+    {
+        public Hallway()
+        {
+            Metadata.ModelId = ModelId;
+        }
+
+        [JsonIgnore]
+        public static new string ModelId { get; } = "dtmi:microsoft:Space:Hallway;1";
+
+        private const string designation = nameof(designation);
+
+        [JsonPropertyName(designation)]
+        public HallwayDesignation? Designation { get; set; }
+    }
+}

--- a/QueryBuilder.Test/Models/HallwayDesignation.cs
+++ b/QueryBuilder.Test/Models/HallwayDesignation.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace QueryBuilder.UnitTests
+{
+    using System.ComponentModel.DataAnnotations;
+    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum HallwayDesignation
+    {
+        [EnumMember(Value = "Primary"), Display(Name = "Primary")]
+        Primary,
+        [EnumMember(Value = "Secondary"), Display(Name = "Secondary")]
+        Secondary
+    }
+}

--- a/QueryBuilder.Test/Models/WBuilding.cs
+++ b/QueryBuilder.Test/Models/WBuilding.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace QueryBuilder.UnitTests
+{
+    using System.Text.Json.Serialization;
+
+    public class WBuilding : Building
+    {
+        public WBuilding()
+        {
+            Metadata.ModelId = ModelId;
+        }
+
+        [JsonIgnore]
+        public static new string ModelId { get; } = "dtmi:microsoft:Space:Building:WBuilding;1";
+
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        [JsonPropertyName("landlordName")]
+        public string LandlordName { get; set; }
+    }
+}

--- a/QueryBuilder.Test/QueryBuilder.Typed/From.UnitTests.cs
+++ b/QueryBuilder.Test/QueryBuilder.Typed/From.UnitTests.cs
@@ -3,6 +3,7 @@
 
 namespace QueryBuilder.UnitTests.QueryBuilder.Typed
 {
+    using Azure.DigitalTwins.Core;
     using Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -25,6 +26,20 @@ namespace QueryBuilder.UnitTests.QueryBuilder.Typed
                 .From<Building>("bldng");
 
             Assert.AreEqual($"SELECT bldng FROM DIGITALTWINS bldng WHERE IS_OF_MODEL(bldng, '{Building.ModelId.UpdateVersion(1)}')", query.BuildAdtQuery());
+        }
+
+        [TestMethod]
+        public void FromGeneratesSelectAllBasicDigitalTwins()
+        {
+            var query = QueryBuilder
+                .From<BasicDigitalTwin>();
+
+            Assert.AreEqual("SELECT basicdigitaltwin FROM DIGITALTWINS basicdigitaltwin", query.BuildAdtQuery());
+
+            query = QueryBuilder
+                .From<BasicDigitalTwin>("twin");
+
+            Assert.AreEqual("SELECT twin FROM DIGITALTWINS twin", query.BuildAdtQuery());
         }
     }
 }

--- a/QueryBuilder/Common/Clauses/Condition.cs
+++ b/QueryBuilder/Common/Clauses/Condition.cs
@@ -72,6 +72,12 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Common.Clauses
 
         internal string Model { get; set; }
 
+        public WhereIsOfModelCondition(string modelAlias, string model)
+        {
+            Alias = modelAlias;
+            Model = model;
+        }
+
         public override string ToString()
         {
             return $"{IsOfModel}({Alias}, '{GetModelWithVersion(Model, minTwinVersion)}')";

--- a/QueryBuilder/Dynamic/Statements/TwinsWhereStatement.cs
+++ b/QueryBuilder/Dynamic/Statements/TwinsWhereStatement.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Dynamic.Statement
         /// <returns>A conjunction class that supports appending more conditions to the WHERE statements via OR or AND terms.</returns>
         public CompoundWhereStatement<TwinsWhereStatement> IsOfModel(string dtmi)
         {
-            WhereClause.AddCondition(new WhereIsOfModelCondition { Alias = this.Alias, Model = dtmi });
+            WhereClause.AddCondition(new WhereIsOfModelCondition(this.Alias, dtmi));
             return new CompoundWhereStatement<TwinsWhereStatement>(JoinClauses, WhereClause, Alias);
         }
 

--- a/QueryBuilder/QueryBuilder.cs
+++ b/QueryBuilder/QueryBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder
@@ -22,7 +22,7 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder
     public static class QueryBuilder
     {
         /// <summary>
-        /// Sets the root type of the query (the FROM clause), filters the correct type, and adds a select clause.
+        /// Sets the root type of the query (the FROM clause), filters the correct type, and adds a select clause. When using BasicDigitalTwin as the root type, there is no type filtered.
         /// </summary>
         /// <typeparam name="TModel">The root type of the query.</typeparam>
         /// <param name="alias">Optional string alias to map to the root type.</param>
@@ -43,11 +43,10 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder
 
             var model = Activator.CreateInstance<TModel>().Metadata.ModelId;
             var whereClause = new WhereClause();
-            whereClause.AddCondition(new WhereIsOfModelCondition
+            if (!typeof(TModel).Equals(typeof(BasicDigitalTwin)))
             {
-                Alias = rootAlias,
-                Model = model
-            });
+                whereClause.AddCondition(new WhereIsOfModelCondition(rootAlias, model));
+            }
 
             var selectClause = new SelectClause();
             selectClause.Add(rootAlias);

--- a/QueryBuilder/Typed/FilteredQuery.cs
+++ b/QueryBuilder/Typed/FilteredQuery.cs
@@ -146,6 +146,23 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Typed
         }
 
         /// <summary>
+        /// Add an isOfModel operator.
+        /// It is recommended only to use the isOfModel operator when there is no model inferred from the FROM clause. No model is inferred when using the root type BasicDigitalTwin in the FROM clause.
+        /// </summary>
+        /// <typeparam name="TBase">Base model type.</typeparam>
+        /// <typeparam name="TDerived">Derived model type.</typeparam>
+        /// <param name="alias">Optional - Model Alias.</param>
+        /// <returns>ADT query instance.</returns>
+        public TQuery WhereIsOfModel<TBase, TDerived>(string alias = null)
+            where TBase : BasicDigitalTwin
+            where TDerived : TBase
+        {
+            whereClause.AddCondition(CreateWhereIsOfModelCondition<TBase, TDerived>(alias));
+
+            return (TQuery)this;
+        }
+
+        /// <summary>
         /// Add a Start with where clause.
         /// </summary>
         /// <typeparam name="TModel">Model type.</typeparam>
@@ -359,6 +376,16 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Typed
                 Value = values,
                 Alias = modelAlias
             };
+        }
+
+        private WhereIsOfModelCondition CreateWhereIsOfModelCondition<TBase, TDerived>(string alias = null)
+            where TBase : BasicDigitalTwin
+            where TDerived : BasicDigitalTwin
+        {
+            var modelAlias = ValidateAndGetAlias<TBase>(typeof(TBase), alias);
+            var model = Activator.CreateInstance<TDerived>().Metadata.ModelId;
+
+            return new WhereIsOfModelCondition(modelAlias, model);
         }
 
         private WhereScalarFunctionCondition CreateAdtScalarBinaryOperatorCondition<TModel>(string propertyName, string value, Type type, string alias, ScalarOperator binaryOperator)

--- a/QueryBuilder/Typed/JoinQuery.cs
+++ b/QueryBuilder/Typed/JoinQuery.cs
@@ -90,11 +90,7 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Typed
             var twinModel = Activator.CreateInstance<TJoinWith>().Metadata.ModelId;
             if (!string.IsNullOrEmpty(twinModel))
             {
-                whereClause.AddCondition(new WhereIsOfModelCondition
-                {
-                    Alias = joinWithAlias,
-                    Model = twinModel
-                });
+                whereClause.AddCondition(new WhereIsOfModelCondition(joinWithAlias, twinModel));
             }
 
             return (TQuery)this;

--- a/README.md
+++ b/README.md
@@ -151,6 +151,34 @@ AND bldng.$dtId = 'ID' AND (bldng.count > 20
 OR (bldng.count < 10 AND ENDSWITH(rel.maxPriority, 'word')))
 ```
 
+```csharp
+var query = QueryBuilder
+                    .From<Space>()
+                    .WhereStartsWith<Space>(s => s.Name, "word")
+                    .Or(query => query
+                        .WhereIsOfModel<Space, Building>()
+                        .WhereIsOfModel<Space, Floor>())
+                    .Not(query => query
+                        .WhereIsOfModel<Space, ConferenceRoom>());
+/* 
+Generated query - uses IS_OF_MODEL & OR
+SELECT space FROM DIGITALTWINS space 
+WHERE IS_OF_MODEL(space, 'dtmi:microsoft:Space;1') 
+AND STARTSWITH(space.name, 'word') 
+AND (IS_OF_MODEL(space, 'dtmi:microsoft:Space:Building;1') OR IS_OF_MODEL(space, 'dtmi:microsoft:Space:Floor;1'))
+AND NOT IS_OF_MODEL(space, 'dtmi:microsoft:Space:ConferenceRoom;1')
+*/
+```
+
+```csharp
+var query = QueryBuilder
+                .From<BasicDigitalTwin>();
+/* 
+Generated query - select all twins
+SELECT basicdigitaltwin 
+FROM DIGITALTWINS basicdigitaltwin
+*/
+```
 ___
 
 ### Methods
@@ -173,6 +201,7 @@ Methods supported in the Typed flow.
     - WhereIn\<TModel\>(propertyName, values)
     - WhereNotIn\<TModel\>(propertySelector, values)
     - WhereNotIn\<TModel\>(propertyName, values)
+    - WhereIsOfModel\<TBase,TDerived\>()
     - Join\<TJoinFrom,TJoinWith\>(relationship)
     - Select\<TSelect\>()
     - Top(numberOfRecords)
@@ -190,7 +219,7 @@ ___
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| TModel, TJoinFrom, TJoinWith, TSelect | A [Type](https://docs.microsoft.com/en-us/dotnet/api/system.type) that's a sub-type of [Azure.DigitalTwins.Core.BasicDigitalTwin](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicDigitalTwin.cs). | The C# model of the twin. |
+| TModel, TJoinFrom, TJoinWith, TSelect, TBase, TDerived | A [Type](https://docs.microsoft.com/en-us/dotnet/api/system.type) that's a sub-type of [Azure.DigitalTwins.Core.BasicDigitalTwin](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Models/BasicDigitalTwin.cs). | The C# model of the twin. |
 | propertySelector | [Expression<Func<TModel, object>>](https://docs.microsoft.com/en-us/dotnet/api/system.linq.expressions.expression-1) | Expression to select any property of TModel type.|
 | propertyName | string | JSON property name of TModel type.  |
 | operation | ComparisonOperators | Operator for the condition. |


### PR DESCRIPTION
## Overview
This PR adds the `WhereIsOfModel` operator to the query builder. 
Testing was added and the README.md file was updated with two examples.

## Example Operator *is_of_model*
### Query Generation
```csharp
var query = QueryBuilder
                    .From<Space>()
                    .WhereStartsWith<Space>(s => s.Name, "word")
                    .Or(query => query
                        .WhereIsOfModel<Space, Building>()
                        .WhereIsOfModel<Space, Floor>());
```

### Generated Query
```sql
SELECT space FROM DIGITALTWINS space 
WHERE IS_OF_MODEL(space, 'dtmi:microsoft:Space;1') 
AND STARTSWITH(space.name, 'word') 
AND (IS_OF_MODEL(space, 'dtmi:microsoft:Space:Building;1') OR IS_OF_MODEL(space, 'dtmi:microsoft:Space:Floor;1'))
```

## Example Query All Twins
### Query Generation
```csharp
var query = QueryBuilder
                    .From<BasicDigitalTwin>();
```

### Generated Query
```sql
SELECT basicdigitaltwin FROM DIGITALTWINS basicdigitaltwin
```

+semver feature 