### PR TITLE
Fix compatibility for non .NET 6 frameworks

### DIFF
--- a/QueryBuilder/QueryBuilder.csproj
+++ b/QueryBuilder/QueryBuilder.csproj
@@ -21,6 +21,14 @@
         <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+        <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+        <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
+    </ItemGroup>
+
     <ItemGroup>
         <PackageReference Include="Azure.DigitalTwins.Core" Version="1.2.2" />
         <PackageReference Include="MinVer" PrivateAssets="all" Version="3.1.0"/>
@@ -28,6 +36,5 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Version 6.0.0 of System.Text.Encodings.Web is incompatible with non-.NET 6 packages which use version 5.x.

Added a conditional package reference to support said consumers.