### PR TITLE
Fix for union sequences

### DIFF
--- a/QueryBuilder.Test/QueryBuilder.Dynamic/Where.UnitTests.cs
+++ b/QueryBuilder.Test/QueryBuilder.Dynamic/Where.UnitTests.cs
@@ -299,6 +299,54 @@ namespace QueryBuilder.UnitTests.QueryBuilder.Dynamic
         }
 
         [TestMethod]
+        public void CanProcessUnionAndIntersectionSequenceConditions()
+        {
+            var query = QueryBuilder.FromTwins()
+                .Where(t => t
+                    .IsOfModel(Space.ModelId.UpdateVersion(1))
+                    .Or()
+                    .TwinProperty("count").IsGreaterThan(20)
+                    .Or()
+                    .TwinProperty("name").NotEqualTo("building 1"));
+
+            Assert.AreEqual($"SELECT twin FROM DIGITALTWINS twin WHERE IS_OF_MODEL(twin, 'dtmi:microsoft:Space;1') OR twin.count > 20 OR twin.name != 'building 1'", query.BuildAdtQuery());
+
+            query = QueryBuilder.FromTwins()
+                .Where(t => t
+                    .IsOfModel(Space.ModelId.UpdateVersion(1))
+                    .Or()
+                    .TwinProperty("count").IsGreaterThan(20)
+                    .Or()
+                    .Not()
+                    .Not()
+                    .TwinProperty("name").NotEqualTo("building 1"));
+
+            Assert.AreEqual($"SELECT twin FROM DIGITALTWINS twin WHERE IS_OF_MODEL(twin, 'dtmi:microsoft:Space;1') OR twin.count > 20 OR NOT NOT twin.name != 'building 1'", query.BuildAdtQuery());
+
+            query = QueryBuilder.FromTwins()
+                .Where(t => t
+                    .IsOfModel(Space.ModelId.UpdateVersion(1))
+                    .And()
+                    .TwinProperty("count").IsGreaterThan(20)
+                    .And()
+                    .TwinProperty("name").NotEqualTo("building 1"));
+
+            Assert.AreEqual($"SELECT twin FROM DIGITALTWINS twin WHERE IS_OF_MODEL(twin, 'dtmi:microsoft:Space;1') AND twin.count > 20 AND twin.name != 'building 1'", query.BuildAdtQuery());
+
+            query = QueryBuilder.FromTwins()
+                .Where(t => t
+                    .IsOfModel(Space.ModelId.UpdateVersion(1))
+                    .Or()
+                    .IsOfModel(Building.ModelId.UpdateVersion(1))
+                    .And()
+                    .TwinProperty("count").IsGreaterThan(20)
+                    .And()
+                    .TwinProperty("name").NotEqualTo("building 1"));
+
+            Assert.AreEqual($"SELECT twin FROM DIGITALTWINS twin WHERE IS_OF_MODEL(twin, 'dtmi:microsoft:Space;1') OR IS_OF_MODEL(twin, 'dtmi:microsoft:Space:Building;1') AND twin.count > 20 AND twin.name != 'building 1'", query.BuildAdtQuery());
+        }
+
+        [TestMethod]
         public void CanApplyComparisonConditions()
         {
             var query = QueryBuilder

--- a/QueryBuilder/Common/Clauses/WhereClause.cs
+++ b/QueryBuilder/Common/Clauses/WhereClause.cs
@@ -51,11 +51,6 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Common.Clauses
                 {
                     continue;
                 }
-                else if (Conditions[i] == Not)
-                {
-                    HandleNots(builder, $"{Not} ", ref next);
-                    i = next;
-                }
                 else
                 {
                     var and = i == 0 ? string.Empty : $"{And} ";

--- a/QueryBuilder/Common/Clauses/WhereClause.cs
+++ b/QueryBuilder/Common/Clauses/WhereClause.cs
@@ -54,13 +54,15 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Common.Clauses
                 else if (Conditions[i] == Not)
                 {
                     HandleNots(builder, $"{Not} ", ref next);
-                    i += next;
+                    i = next;
                 }
                 else
                 {
-                    var and = i == 0 ? string.Empty : $" {And} ";
+                    var and = i == 0 ? string.Empty : $"{And} ";
                     builder.Append($"{and}{Conditions[i]}");
                 }
+
+                TryAppendSpace(builder, i);
             }
 
             return builder.ToString();
@@ -74,24 +76,48 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Common.Clauses
 
         private bool TryHandleCompoundStatement(StringBuilder builder, ref int next, ref int i)
         {
-            if (next < Conditions.Count && (Conditions[next] == Or || Conditions[next] == And))
+            if (i == 0)
             {
-                var compound = Conditions[next];
-                next++;
-                if (Conditions[next] != Not)
+                if (Conditions[i] == Not)
                 {
-                    builder.Append($"{Conditions[i]} {compound} {Conditions[next]}");
-                    i += next;
+                    HandleNots(builder, $"{Not} ", ref next);
+                    i = next;
+                    TryAppendSpace(builder, i);
                     return true;
                 }
 
-                next++;
-                HandleNots(builder, $"{Conditions[i]} {compound} {Not} ", ref next);
-                i += next;
+                builder.Append($"{Conditions[i]}");
+                TryAppendSpace(builder, i);
+                return true;
+            }
+            else if (next < Conditions.Count && (Conditions[i] == Or || Conditions[i] == And))
+            {
+                var compound = Conditions[i];
+
+                if (Conditions[next] == Not)
+                {
+                    HandleNots(builder, $"{compound} ", ref next);
+                    i = next;
+                    TryAppendSpace(builder, i);
+                    return true;
+                }
+
+                builder.Append($"{compound} {Conditions[next]}");
+                i++;
+                TryAppendSpace(builder, i);
+
                 return true;
             }
 
             return false;
+        }
+
+        private void TryAppendSpace(StringBuilder builder, int i)
+        {
+            if (i + 1 < Conditions.Count)
+            {
+                builder.Append(" ");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### QueryBuilder Sequence Error

This PR fixes the issue and adds unit testing for union sequences.
The current QueryBuilder implementation has a bug when creating a sequence of unions, which results in the following.

```csharp
var exQeuery01 = QueryBuilder.FromTwins()
    .Where(t => t
         .IsOfModel(Space.ModelId.UpdateVersion(1))
         .Or()
         .TwinProperty("count").IsGreaterThan(20)
         .Or()
         .TwinProperty("name").NotEqualTo("building 1"));
```

#### Expected

```sql
SELECT twin FROM DIGITALTWINS twin WHERE IS_OF_MODEL(twin, 'dtmi:microsoft:Space;1') OR twin.count > 20 OR twin.name != 'building 1'
```

#### Actual

```sql
SELECT twin FROM DIGITALTWINS twin WHERE IS_OF_MODEL(twin, 'dtmi:microsoft:Space;1') OR twin.count > 20 AND OR AND twin.name != 'building 1'
```