### PR TITLE
Add string filter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,7 @@ ModelManifest.xml
 
 coveragereports/
 coverage.xml
+coverage/
 
 # sign script files
 unsigned/

--- a/QueryBuilder.Test/QueryBuilder.Dynamic/Join.UnitTests.cs
+++ b/QueryBuilder.Test/QueryBuilder.Dynamic/Join.UnitTests.cs
@@ -74,6 +74,34 @@ namespace QueryBuilder.UnitTests.QueryBuilder.Dynamic
         }
 
         [TestMethod]
+        public void CanUseStringWhereConditionWithJoin()
+        {
+            var query = QueryBuilder
+                .FromTwins("bldng")
+                .Join(b => b
+                    .With("flr")
+                    .RelatedBy("hasChildren")
+                    .As("rel")
+                    .Where("flr.name eq 'floor1'"));
+
+            Assert.AreEqual($"SELECT bldng FROM DIGITALTWINS bldng JOIN flr RELATED bldng.hasChildren rel WHERE flr.name = 'floor1'", query.BuildAdtQuery());
+        }
+
+        [TestMethod]
+        public void JoinWhereAddsNoConditionIfStringIsNullOrEmpty()
+        {
+            var query = QueryBuilder
+                .FromTwins("bldng")
+                .Join(b => b
+                    .With("flr")
+                    .RelatedBy("hasChildren")
+                    .As("rel")
+                    .Where(string.Empty));
+
+            Assert.AreEqual($"SELECT bldng FROM DIGITALTWINS bldng JOIN flr RELATED bldng.hasChildren rel", query.BuildAdtQuery());
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         public void CanNotAssignAliasAlreadyUsed()
         {

--- a/QueryBuilder.Test/QueryBuilder.Dynamic/Where.UnitTests.cs
+++ b/QueryBuilder.Test/QueryBuilder.Dynamic/Where.UnitTests.cs
@@ -553,6 +553,22 @@ namespace QueryBuilder.UnitTests.QueryBuilder.Dynamic
                     .Select("twin", "hasAddressTwin", "hasCityTwin")
                     .BuildAdtQuery();
             Assert.AreEqual("SELECT twin, hasAddressTwin, hasCityTwin FROM DIGITALTWINS twin JOIN hasAddressTwin RELATED twin.hasAddress hasaddressrelationship JOIN hasCityTwin RELATED hasAddressTwin.hasCity hascityrelationship WHERE IS_OF_MODEL(twin, 'dtmi:space:building;1') AND twin.name = '122'", queryString);
+
+            queryString = QueryBuilder
+                        .FromTwins()
+                        .Where($"not twin.name eq 'building1'")
+                        .BuildAdtQuery();
+            Assert.AreEqual("SELECT twin FROM DIGITALTWINS twin WHERE NOT twin.name = 'building1'", queryString);
+        }
+
+        [TestMethod]
+        public void StringsInScalarFunctionsAreNotOverwritten()
+        {
+            var queryString = QueryBuilder
+                    .FromTwins()
+                    .Where($"twin.name equals 'building1' and not contains(twin.description, 'myname has an equals in it')")
+                    .BuildAdtQuery();
+            Assert.AreEqual("SELECT twin FROM DIGITALTWINS twin WHERE twin.name = 'building1' AND NOT CONTAINS(twin.description, 'myname has an equals in it')", queryString);
         }
 
         [TestMethod]

--- a/QueryBuilder/Common/Helpers/FilterHelper.cs
+++ b/QueryBuilder/Common/Helpers/FilterHelper.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Common.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Common.Clauses;
+
+    internal static class FilterHelper
+    {
+        private static readonly IDictionary<string, string> binaryOperatorMap = new Dictionary<string, string>
+        {
+            { " eq ", " = " },
+            { " equals ", " = " },
+            { " == ", " = " },
+            { " notequals ", " != " },
+            { " ne ", " != " },
+            { " neq ", " != " },
+            { " !== ", " != " },
+            { " lt ", " < " },
+            { " le ", " <= " },
+            { " lte ", " <= " },
+            { " gt ", " > " },
+            { " ge ", " >= " },
+            { " gte ", " >= " }
+        };
+
+        private static readonly IDictionary<string, string> scalarFunctionMap = new Dictionary<string, string>
+        {
+            { "isofmodel(", "IS_OF_MODEL(" },
+            { "is_of_model(", "IS_OF_MODEL(" },
+            { "contains(", "CONTAINS(" },
+            { "startswith(", "STARTSWITH(" },
+            { "endswith(", "ENDSWITH(" },
+            { " in [", " IN [" },
+            { " notin [", " NIN [" },
+            { " nin [", " NIN [" }
+        };
+
+        private static readonly IDictionary<string, string> compoundOperatorMap = new Dictionary<string, string>
+        {
+            { " || ", " OR " },
+            { " or ", " OR " },
+            { " and ", " AND " },
+            { " && ", " AND " }
+        };
+
+        internal static string ReplaceOperators(string queryText) => ReplaceWithMap(binaryOperatorMap, queryText);
+
+        internal static string ReplaceScalarFunctions(string queryText) => ReplaceWithMap(scalarFunctionMap, queryText);
+
+        internal static string ReplaceCompoundOperators(string queryText) => ReplaceWithMap(compoundOperatorMap, queryText);
+
+        internal static string FixRelationshipNames(string queryText, IEnumerable<JoinClause> joinClauses)
+        {
+            if (!joinClauses.Any())
+            {
+                return queryText;
+            }
+
+            var newString = queryText;
+            var names = queryText.Split(' ');
+            foreach (var name in names)
+            {
+                if (name.Contains('.'))
+                {
+                    var left = name.Split('.').First();
+                    foreach (var clause in joinClauses)
+                    {
+                        if (clause.Relationship.Equals(left, StringComparison.OrdinalIgnoreCase))
+                        {
+                            newString = newString.Replace($"{left}.", $"{clause.RelationshipAlias}.");
+                        }
+                    }
+                }
+            }
+
+            return newString;
+        }
+
+        private static string ReplaceWithMap(IDictionary<string, string> map, string queryText)
+        {
+            var newQueryText = queryText;
+            foreach (var key in map.Keys)
+            {
+                if (newQueryText.Contains(key))
+                {
+                    newQueryText = newQueryText.Replace(key, map[key]);
+                }
+            }
+
+            return newQueryText;
+        }
+    }
+}

--- a/QueryBuilder/Dynamic/FilterQuery.cs
+++ b/QueryBuilder/Dynamic/FilterQuery.cs
@@ -31,5 +31,24 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Dynamic
             whereLogic.Invoke(statement);
             return (TQuery)this;
         }
+
+        /// <summary>
+        /// An alternative way to add a WHERE clause to the query by directly providing a string that contains the condition.
+        /// </summary>
+        /// <param name="filter">The verbatim condition in string format.</param>
+        /// <returns>Query that contains a WHERE clause and conditional arguments.</returns>
+        public TQuery Where(string filter)
+        {
+            if (!string.IsNullOrEmpty(filter))
+            {
+                var fixedFilter = FilterHelper.ReplaceOperators(filter);
+                fixedFilter = FilterHelper.ReplaceScalarFunctions(fixedFilter);
+                fixedFilter = FilterHelper.ReplaceCompoundOperators(fixedFilter);
+                fixedFilter = FilterHelper.FixRelationshipNames(fixedFilter, joinClauses);
+                whereClause.AddCondition(fixedFilter);
+            }
+
+            return (TQuery)this;
+        }
     }
 }

--- a/QueryBuilder/Dynamic/Statements/CompoundWhereStatement.cs
+++ b/QueryBuilder/Dynamic/Statements/CompoundWhereStatement.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Dynamic.Statement
 
         internal WhereClause WhereClause { get; private set; }
 
-        private string alias;
+        private readonly string alias;
 
         internal CompoundWhereStatement(IList<JoinClause> joinClauses, WhereClause whereClause, string alias)
         {

--- a/QueryBuilder/Dynamic/Statements/JoinFinalStatement.cs
+++ b/QueryBuilder/Dynamic/Statements/JoinFinalStatement.cs
@@ -40,6 +40,25 @@ namespace Microsoft.DigitalWorkplace.DigitalTwins.QueryBuilder.Dynamic.Statement
             return whereLogic.Invoke(statement);
         }
 
+        /// <summary>
+        /// An alternative way to add a WHERE clause to the query by directly providing a string that contains the condition.
+        /// </summary>
+        /// <param name="filter">The verbatim condition in string format.</param>
+        /// <returns>An extendible part of a WHERE statement to continue adding WHERE conditions to.</returns>
+        public CompoundWhereStatement<TWhereStatement> Where(string filter)
+        {
+            if (!string.IsNullOrEmpty(filter))
+            {
+                var fixedFilter = FilterHelper.ReplaceOperators(filter);
+                fixedFilter = FilterHelper.ReplaceScalarFunctions(fixedFilter);
+                fixedFilter = FilterHelper.ReplaceCompoundOperators(fixedFilter);
+                fixedFilter = FilterHelper.FixRelationshipNames(fixedFilter, Clauses);
+                WhereClause.AddCondition(fixedFilter);
+            }
+
+            return new CompoundWhereStatement<TWhereStatement>(Clauses, WhereClause, Current.JoinWith);
+        }
+
 #pragma warning disable SA1629
         /// <summary>
         /// Adds a nested JOIN to the existing one. This will contextually bind this JOIN to a parent one.

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ var query = QueryBuilder
 var stringQuery = query.BuildAdtQuery();
 
 /*
-Generated query - uses 'TOP' and 'STARTSWITH' ADT query operator
+Generated query - uses 'COUNT' and 'STARTSWITH' ADT query operator
 
 SELECT COUNT()
 FROM DIGITALTWINS twin
@@ -344,7 +344,7 @@ WHERE STARTSWITH(twin.name, 'name')
 ``` csharp
 var query = QueryBuilder
                 .FromTwins()
-                .Count()
+                .TOP(5)
                 .Where(b => b
                     .TwinProperty("name")
                     .Contains("ame"));
@@ -354,7 +354,7 @@ var stringQuery = query.BuildAdtQuery();
 /*
 Generated query - uses 'TOP' and 'CONTAINS' ADT query operator
 
-SELECT COUNT()
+SELECT TOP(5) twin
 FROM DIGITALTWINS twin
 WHERE CONTAINS(twin.name, 'ame')
 */
@@ -394,6 +394,21 @@ WHERE bldng.$dtId = 'ID' AND (bldng.count > 20
 OR (bldng.count < 10 AND ENDSWITH(rel.maxPriority, 'word')))
 ```
 
+``` csharp
+var query = QueryBuilder
+            .FromTwins()
+            .Where("startswith(twin.name, 'name1')");
+
+var stringQuery = query.BuildAdtQuery();
+
+/*
+Generated query - uses 'STARTSWITH' ADT query operator
+
+SELECT twin
+FROM DIGITALTWINS twin
+WHERE STARTSWITH(twin.name, 'name1')
+*/
+```
 ___
 
 ### Methods
@@ -402,6 +417,7 @@ Methods supported in the Dynamic flow.
 
 - QueryBuilder
   - FromTwins()
+    - Where(filter)
     - Where(whereLogic)
     - Join(joinLogic)
     - Join(joinAndWhereLogic)
@@ -410,7 +426,8 @@ Methods supported in the Dynamic flow.
     - Count()
     - BuildAdtQuery()
   - FromRelationships()
-    - Where()
+    - Where(filter)
+    - Where(whereLogic)
     - Select(aliases)
     - Top(numberOfRecords)
     - Count()
@@ -424,6 +441,7 @@ Methods supported in the Dynamic flow.
 | ---- | ---- | ----------- |
 | TWhereStatement, CompoundWhereStatement, JoinWithStatement, JoinFinalStatement | | These types are all part of the Where and Join methods' inner fluent syntax that aid in building and enforcing particular query semantics. |
 | whereLogic | [Func<TWhereStatement, CompoundWhereStatement<TWhereStatement>>](https://docs.microsoft.com/en-us/dotnet/api/system.func-2) | Func to include WHERE logic in the query. |
+| filter | string | A string filter query that can contain one or multiple conditions |
 | joinLogic | [Func\<JoinWithStatement\<TWhereStatement\>, JoinFinalStatement\<TWhereStatement\>\>](https://docs.microsoft.com/en-us/dotnet/api/system.func-2) | Func to include JOIN logic in the query. |
 | joinAndWhereLogic | [Func\<JoinWithStatement\<TWhereStatement\>, CompoundWhereStatement\<TWhereStatement\>\>]() | Func to include JOIN logic in the query with additional WHERE logic scoped to the JOIN. |
 | aliases | params object[] | This can be one or many aliases to override and apply to the SELECT clause of the query.

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ WHERE STARTSWITH(twin.name, 'name')
 ``` csharp
 var query = QueryBuilder
                 .FromTwins()
-                .TOP(5)
+                .Top(5)
                 .Where(b => b
                     .TwinProperty("name")
                     .Contains("ame"));


### PR DESCRIPTION
1. Added support to pass in string filters to a new `.Where(string)` method on the Dynamic Query Builder.